### PR TITLE
Minor bug fixes and performance improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ PasswordTool_Native_Addon/data/Input/*
 PasswordTool_Native_Addon/data/Stats/*
 PasswordTool_Native_Addon/data/Stats/Patterns Data/*
 !PasswordTool_Native_Addon/data/Stats/Error Log
-!PasswordTool_Native_Addon/data/Stats/Patterns.txt
 !PasswordTool_Native_Addon/data/Stats/Patterns Data/Error Log
 
 #Temp folder
@@ -91,7 +90,6 @@ PasswordTool_CPP_Backend/data/Input/*
 PasswordTool_CPP_Backend/data/Stats/*
 PasswordTool_CPP_Backend/data/Stats/Patterns Data/*
 !PasswordTool_CPP_Backend/data/Stats/Error Log
-!PasswordTool_CPP_Backend/data/Stats/Patterns.txt
 !PasswordTool_CPP_Backend/data/Stats/Patterns Data/Error Log
 
 #Temp folder

--- a/PasswordTool_CPP_Backend/APILayer.h
+++ b/PasswordTool_CPP_Backend/APILayer.h
@@ -290,11 +290,13 @@ namespace APILayer {
 		StatsGenerator::write_key_patterns();
 
 		//delete files as we have generated stats out of them
+		/*
 		for (int i = 0; i < filePaths.size(); i++) {
 			if (remove(filePaths[i].c_str()) != 0) {
 				cout << "ERROR: while deleting file: " + filePaths[i] << endl;
 			}
 		}
+		*/
 	}
 
 	/*

--- a/PasswordTool_CPP_Backend/FileHandler.cpp
+++ b/PasswordTool_CPP_Backend/FileHandler.cpp
@@ -15,17 +15,6 @@ void FileHandler::get_files_recursive(deque<string>& fileNames, string directory
 			fileNames.push_back(entry.path().string());
 		}
 	}
-	/*
-	for (const auto& entry : experimental::filesystem::recursive_directory_iterator(directoryPath))
-		if (entry.path().string() != "Error Log") {
-			fileNames.push_back(entry.path().string());
-		}
-	*/
-	/*
-	if code is working file you can delete this comment section
-	for (const auto& entry : filesystem::recursive_directory_iterator(directoryPath))
-		fileNames.push_back(entry.path().string());
-	*/
 }
 
 void FileHandler::get_files_recursive(vector<string>& fileNames, string directoryPath) {
@@ -41,13 +30,6 @@ void FileHandler::get_files_recursive(vector<string>& fileNames, string director
 			fileNames.push_back(entry.path().string());
 		}
 	}
-	/*
-	for (const auto& entry : experimental::filesystem::recursive_directory_iterator(directoryPath)){
-		if (entry.path().string() != "Error Log") {
-			fileNames.push_back(entry.path().string());
-		}
-	}
-	*/
 }
 
 void FileHandler::read_file(deque<string>& fileContent, string filePath) {
@@ -58,7 +40,7 @@ void FileHandler::read_file(deque<string>& fileContent, string filePath) {
 	ifstream input(filePath);
 
 	if (!input.is_open()) {
-		cout << "File not found " << filePath << "\n";
+		cout << "File not found: " << filePath << "\n";
 	}
 	else
 	{
@@ -79,7 +61,7 @@ void FileHandler::read_file(vector<string>& fileContent, string filePath) {
 	string str;
 	ifstream input(filePath);
 	if (!input.is_open()) {
-		cout << "File not found " << filePath << "\n";
+		cout << "File not found: " << filePath << "\n";
 	}
 	else
 	{
@@ -93,10 +75,33 @@ void FileHandler::read_file(vector<string>& fileContent, string filePath) {
 }
 
 void FileHandler::read_file(unordered_set<string>& fileContent, string filePath) {
+	/*
+		USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN UNORDERED_SET(FILECONTENT)
+	*/
 	string str;
 	ifstream input(filePath);
 	if (!input.is_open()) {
-		cout << "File not found " << filePath << "\n";
+		cout << "File not found: " << filePath << "\n";
+	}
+	else
+	{
+		while (getline(input, str)) {
+			if (str.size() > 0) {
+				fileContent.insert(str);
+			}
+		}
+	}
+	input.close();
+}
+
+void FileHandler::read_file(set<string>& fileContent, string filePath) {
+	/*
+		USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN SET(FILECONTENT)
+	*/
+	string str;
+	ifstream input(filePath);
+	if (!input.is_open()) {
+		cout << "File not found: " << filePath << "\n";
 	}
 	else
 	{
@@ -115,7 +120,7 @@ void FileHandler::write_file(deque<string>& fileContent, string filePath) {
 	*/
 	ofstream output(filePath);
 	if (!output.is_open()) {
-		cout << "There is a problem while writing a file \n"<<filePath<<"\n";
+		cout << "ERROR: Can't find existing or create a new file at this address: \n"<<filePath<<endl;
 		return;
 	}
 	for (auto it = fileContent.begin(); it != fileContent.end(); it++) {
@@ -130,7 +135,22 @@ void FileHandler::write_file(vector<string>& fileContent, string filePath) {
 	*/
 	ofstream output(filePath);
 	if (!output.is_open()) {
-		cout << "There is a problem while writing a file \n";
+		cout << "ERROR: Can't find existing or create a new file at this address: \n" << filePath << endl;
+		return;
+	}
+	for (auto it = fileContent.begin(); it != fileContent.end(); it++) {
+		output << *it << "\n";
+	}
+	output.close();
+}
+
+void FileHandler::write_file(set<string>& fileContent, string filePath) {
+	/*
+		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND WRITING A SET(FILECONTENT) IN IT
+	*/
+	ofstream output(filePath);
+	if (!output.is_open()) {
+		cout << "ERROR: Can't find existing or create a new file at this address: \n" << filePath << endl;
 		return;
 	}
 	for (auto it = fileContent.begin(); it != fileContent.end(); it++) {
@@ -158,6 +178,21 @@ void FileHandler::write_and_append_file(deque<string>& fileContent, string fileP
 void FileHandler::write_and_append_file(vector<string>& fileContent, string filePath) {
 	/*
 		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPEND A VECTOR(FILECONTENT) IN IT
+	*/
+	ofstream appendFile(filePath, ios::app);
+	if (!appendFile.is_open()) {
+		FileHandler::write_file(fileContent, filePath);
+		return;
+	}
+	for (auto it = fileContent.begin(); it != fileContent.end(); it++) {
+		appendFile << *it << "\n";
+	}
+	appendFile.close();
+}
+
+void FileHandler::write_and_append_file(set<string>& fileContent, string filePath) {
+	/*
+		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPEND A SET(FILECONTENT) IN IT
 	*/
 	ofstream appendFile(filePath, ios::app);
 	if (!appendFile.is_open()) {

--- a/PasswordTool_CPP_Backend/FileHandler.h
+++ b/PasswordTool_CPP_Backend/FileHandler.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <deque>
+#include <set>
 #include <unordered_set>
 
 #include"DataCleanser.h"
@@ -40,8 +41,16 @@ public:
 		USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN VECTOR(FILECONTENT)
 	*/
 	static void read_file(vector<string>& fileContent, string filePath);
-
+	
+	/*
+	USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN UNORDERED_SET(FILECONTENT)
+	*/
 	static void read_file(unordered_set<string>& fileContent, string filePath);
+
+	/*
+	USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN SET(FILECONTENT)
+	*/
+	static void read_file(set<string>& fileContent, string filePath);
 
 	/*
 		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND WRITING A DEQUE(FILECONTENT) IN IT
@@ -54,6 +63,11 @@ public:
 	static void write_file(vector<string>& fileContent, string filePath);
 
 	/*
+		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND WRITING A SET(FILECONTENT) IN IT
+	*/
+	static void write_file(set<string>& fileContent, string filePath);
+
+	/*
 		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPENDING A DEQUE(FILECONTENT) IN IT
 	*/
 	static void write_and_append_file(deque<string>& fileContent, string filePath);
@@ -62,6 +76,11 @@ public:
 		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPENDING A VECTOR(FILECONTENT) IN IT
 	*/
 	static void write_and_append_file(vector<string>& fileContent, string filePath);
+
+	/*
+		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPENDING A SET(FILECONTENT) IN IT
+	*/
+	static void write_and_append_file(set<string>& fileContent, string filePath);
 
 	/*
 		HERE WE ARE TAKING A PATH OF DIRECTORY(DIRECTORYPATH) AND RESIZING ALL ITS CONTENT

--- a/PasswordTool_CPP_Backend/StatsGenerator.h
+++ b/PasswordTool_CPP_Backend/StatsGenerator.h
@@ -6,6 +6,7 @@
 #include<thread>
 #include<vector>
 #include<deque>
+#include<set>
 #include<string>
 #include<algorithm>
 #include<mutex>
@@ -50,7 +51,7 @@ public:
 
 	//THREAD SAFE MEMBERS
 	//UNORDERED MAP TO STORE PATTERNS AND THEIR DATA TEMPORARILY
-	unordered_map<string, deque<string>> statsResults;
+	unordered_map<string, set<string>> statsResults;
 	
 	/*
 		FUNCTION TO CLASSIFY PATTERNS, SO THAT SAME PATTERN HAVE A SINGLE FILE FOR ITS DATA.

--- a/PasswordTool_Native_Addon/src/APILayer.h
+++ b/PasswordTool_Native_Addon/src/APILayer.h
@@ -290,11 +290,13 @@ namespace APILayer {
 		StatsGenerator::write_key_patterns();
 
 		//delete files as we have generated stats out of them
+		/*
 		for (int i = 0; i < filePaths.size(); i++) {
 			if (remove(filePaths[i].c_str()) != 0) {
 				cout << "ERROR: while deleting file: " + filePaths[i] << endl;
 			}
 		}
+		*/
 	}
 
 	/*

--- a/PasswordTool_Native_Addon/src/FileHandler.cpp
+++ b/PasswordTool_Native_Addon/src/FileHandler.cpp
@@ -15,17 +15,6 @@ void FileHandler::get_files_recursive(deque<string>& fileNames, string directory
 			fileNames.push_back(entry.path().string());
 		}
 	}
-	/*
-	for (const auto& entry : experimental::filesystem::recursive_directory_iterator(directoryPath))
-		if (entry.path().string() != "Error Log") {
-			fileNames.push_back(entry.path().string());
-		}
-	*/
-	/*
-	if code is working file you can delete this comment section
-	for (const auto& entry : filesystem::recursive_directory_iterator(directoryPath))
-		fileNames.push_back(entry.path().string());
-	*/
 }
 
 void FileHandler::get_files_recursive(vector<string>& fileNames, string directoryPath) {
@@ -41,13 +30,6 @@ void FileHandler::get_files_recursive(vector<string>& fileNames, string director
 			fileNames.push_back(entry.path().string());
 		}
 	}
-	/*
-	for (const auto& entry : experimental::filesystem::recursive_directory_iterator(directoryPath)){
-		if (entry.path().string() != "Error Log") {
-			fileNames.push_back(entry.path().string());
-		}
-	}
-	*/
 }
 
 void FileHandler::read_file(deque<string>& fileContent, string filePath) {
@@ -58,7 +40,7 @@ void FileHandler::read_file(deque<string>& fileContent, string filePath) {
 	ifstream input(filePath);
 
 	if (!input.is_open()) {
-		cout << "File not found " << filePath << "\n";
+		cout << "File not found: " << filePath << "\n";
 	}
 	else
 	{
@@ -79,7 +61,7 @@ void FileHandler::read_file(vector<string>& fileContent, string filePath) {
 	string str;
 	ifstream input(filePath);
 	if (!input.is_open()) {
-		cout << "File not found " << filePath << "\n";
+		cout << "File not found: " << filePath << "\n";
 	}
 	else
 	{
@@ -93,10 +75,33 @@ void FileHandler::read_file(vector<string>& fileContent, string filePath) {
 }
 
 void FileHandler::read_file(unordered_set<string>& fileContent, string filePath) {
+	/*
+		USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN UNORDERED_SET(FILECONTENT)
+	*/
 	string str;
 	ifstream input(filePath);
 	if (!input.is_open()) {
-		cout << "File not found " << filePath << "\n";
+		cout << "File not found: " << filePath << "\n";
+	}
+	else
+	{
+		while (getline(input, str)) {
+			if (str.size() > 0) {
+				fileContent.insert(str);
+			}
+		}
+	}
+	input.close();
+}
+
+void FileHandler::read_file(set<string>& fileContent, string filePath) {
+	/*
+		USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN SET(FILECONTENT)
+	*/
+	string str;
+	ifstream input(filePath);
+	if (!input.is_open()) {
+		cout << "File not found: " << filePath << "\n";
 	}
 	else
 	{
@@ -115,7 +120,7 @@ void FileHandler::write_file(deque<string>& fileContent, string filePath) {
 	*/
 	ofstream output(filePath);
 	if (!output.is_open()) {
-		cout << "There is a problem while writing a file \n"<<filePath<<"\n";
+		cout << "ERROR: Can't find existing or create a new file at this address: \n"<<filePath<<endl;
 		return;
 	}
 	for (auto it = fileContent.begin(); it != fileContent.end(); it++) {
@@ -130,7 +135,22 @@ void FileHandler::write_file(vector<string>& fileContent, string filePath) {
 	*/
 	ofstream output(filePath);
 	if (!output.is_open()) {
-		cout << "There is a problem while writing a file \n";
+		cout << "ERROR: Can't find existing or create a new file at this address: \n" << filePath << endl;
+		return;
+	}
+	for (auto it = fileContent.begin(); it != fileContent.end(); it++) {
+		output << *it << "\n";
+	}
+	output.close();
+}
+
+void FileHandler::write_file(set<string>& fileContent, string filePath) {
+	/*
+		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND WRITING A SET(FILECONTENT) IN IT
+	*/
+	ofstream output(filePath);
+	if (!output.is_open()) {
+		cout << "ERROR: Can't find existing or create a new file at this address: \n" << filePath << endl;
 		return;
 	}
 	for (auto it = fileContent.begin(); it != fileContent.end(); it++) {
@@ -158,6 +178,21 @@ void FileHandler::write_and_append_file(deque<string>& fileContent, string fileP
 void FileHandler::write_and_append_file(vector<string>& fileContent, string filePath) {
 	/*
 		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPEND A VECTOR(FILECONTENT) IN IT
+	*/
+	ofstream appendFile(filePath, ios::app);
+	if (!appendFile.is_open()) {
+		FileHandler::write_file(fileContent, filePath);
+		return;
+	}
+	for (auto it = fileContent.begin(); it != fileContent.end(); it++) {
+		appendFile << *it << "\n";
+	}
+	appendFile.close();
+}
+
+void FileHandler::write_and_append_file(set<string>& fileContent, string filePath) {
+	/*
+		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPEND A SET(FILECONTENT) IN IT
 	*/
 	ofstream appendFile(filePath, ios::app);
 	if (!appendFile.is_open()) {

--- a/PasswordTool_Native_Addon/src/FileHandler.h
+++ b/PasswordTool_Native_Addon/src/FileHandler.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <deque>
+#include <set>
 #include <unordered_set>
 
 #include"DataCleanser.h"
@@ -40,8 +41,16 @@ public:
 		USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN VECTOR(FILECONTENT)
 	*/
 	static void read_file(vector<string>& fileContent, string filePath);
-
+	
+	/*
+	USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN UNORDERED_SET(FILECONTENT)
+	*/
 	static void read_file(unordered_set<string>& fileContent, string filePath);
+
+	/*
+	USING IFSTREAM TO OPEN A FILE(FILEPATH) AND READING ITS CONTENT IN SET(FILECONTENT)
+	*/
+	static void read_file(set<string>& fileContent, string filePath);
 
 	/*
 		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND WRITING A DEQUE(FILECONTENT) IN IT
@@ -54,6 +63,11 @@ public:
 	static void write_file(vector<string>& fileContent, string filePath);
 
 	/*
+		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND WRITING A SET(FILECONTENT) IN IT
+	*/
+	static void write_file(set<string>& fileContent, string filePath);
+
+	/*
 		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPENDING A DEQUE(FILECONTENT) IN IT
 	*/
 	static void write_and_append_file(deque<string>& fileContent, string filePath);
@@ -62,6 +76,11 @@ public:
 		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPENDING A VECTOR(FILECONTENT) IN IT
 	*/
 	static void write_and_append_file(vector<string>& fileContent, string filePath);
+
+	/*
+		USING OF OFSTREAM TO OPEN A FILE(FILEPATH) AND APPENDING A SET(FILECONTENT) IN IT
+	*/
+	static void write_and_append_file(set<string>& fileContent, string filePath);
 
 	/*
 		HERE WE ARE TAKING A PATH OF DIRECTORY(DIRECTORYPATH) AND RESIZING ALL ITS CONTENT

--- a/PasswordTool_Native_Addon/src/StatsGenerator.h
+++ b/PasswordTool_Native_Addon/src/StatsGenerator.h
@@ -6,6 +6,7 @@
 #include<thread>
 #include<vector>
 #include<deque>
+#include<set>
 #include<string>
 #include<algorithm>
 #include<mutex>
@@ -50,7 +51,7 @@ public:
 
 	//THREAD SAFE MEMBERS
 	//UNORDERED MAP TO STORE PATTERNS AND THEIR DATA TEMPORARILY
-	unordered_map<string, deque<string>> statsResults;
+	unordered_map<string, set<string>> statsResults;
 	
 	/*
 		FUNCTION TO CLASSIFY PATTERNS, SO THAT SAME PATTERN HAVE A SINGLE FILE FOR ITS DATA.


### PR DESCRIPTION
C++ backend: stats generator function now use std::set (c++ binary map container) this will prevent duplicate records. Previously we used std::deque to read records and std::sort to sort them then std::unique to remove duplicates, it was slow and required more memory. New method do not read duplicate records at the first place, so we don't get any duplicate records and no need to perform sort and unique operation.
